### PR TITLE
Optimize usages of tag.addId to use varargs instead of loops

### DIFF
--- a/src/minecraft/scripts/item_durability.zs
+++ b/src/minecraft/scripts/item_durability.zs
@@ -37,7 +37,6 @@ for durability, items in itemsForDurability{
   // //
   // Sets up items to use the Unbreakable tag as this is a much cleaner
   // method for many items rather than setting durability
-  // <tagmanager:items>.addId(<tag:items:datamancy:unbreakable>, <resource:%1%>);
   // //
 
 val itemsForUnbreakable = [
@@ -654,6 +653,4 @@ val itemsForUnbreakable = [
 
 ];
 
-for item in itemsForUnbreakable{
-  <tagmanager:items>.addId(<tag:items:datamancy:unbreakable>, item);
-}
+<tag:items:datamancy:unbreakable>.addId(itemsForUnbreakable);

--- a/src/minecraft/scripts/tags.zs
+++ b/src/minecraft/scripts/tags.zs
@@ -1,5 +1,6 @@
 import crafttweaker.api.tag.manager.ITagManager;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.resource.ResourceLocation;
 
 val itemsToRemove as IItemStack[] = [
   <item:forcecraft:force_stick>,
@@ -419,48 +420,6 @@ for item in itemsToRemove {
   }
 }
 
-// Tag additions
-<tagmanager:items>.addId(<tag:items:forge:dusts/ender>, <resource:thermal:ender_pearl_dust>);
-<tagmanager:items>.addId(<tag:items:minecraft:pressure_plates>, <resource:minecraft:stone_pressure_plate>);
-
-// Adds Crafting Tables to forge:workbench tag
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:enderio:painted_crafting_table>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_none>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_black>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_blue>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_brown>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_cyan>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_gray>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_green>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_light_blue>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_light_gray>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_lime>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_magenta>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_orange>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_pink>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_purple>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_red>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_white>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_yellow>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:minecraft:crafting_table>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:cyclic:workbench>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:craftingstation:crafting_station>);
-<tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:craftingstation:crafting_station_slab>);
-
-// Using this as a test for goat spawns not working on this block normally
-<tagmanager:blocks>.addId(<tag:blocks:minecraft:dirt>, <resource:colouredstuff:dirt_none>);
-
-
-// Adding every block to the dragon immune tag
-for block in game.blocks {
-  <tag:blocks:minecraft:dragon_immune>.add(block);
-}
-
-
-// Tags each set of Coloured Stuff blocks
-
-<tag:blocks:skyfactory_5:coloured_stuff/crafting_tables>.addId(<resource:colouredstuff:crafting_table_rainbow>);
-
 var colors = [
     "black",
     "blue",
@@ -480,49 +439,74 @@ var colors = [
     "yellow"
 ];
 
-for color in colors {
-    <tag:blocks:skyfactory_5:coloured_stuff/logs>.addId(<resource:colouredstuff:log_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wood>.addId(<resource:colouredstuff:wood_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/planks>.addId(<resource:colouredstuff:planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/logs>.addId(<resource:colouredstuff:log_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/log_stripped>.addId(<resource:colouredstuff:log_stripped_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wood_stripped>.addId(<resource:colouredstuff:wood_stripped_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/crafting_tables>.addId(<resource:colouredstuff:crafting_table_rainbow>);
-    <tag:blocks:skyfactory_5:coloured_stuff/leaves>.addId(<resource:colouredstuff:leaves_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/saplings>.addId(<resource:colouredstuff:sapling_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/cobblestone>.addId(<resource:colouredstuff:cobblestone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stone>.addId(<resource:colouredstuff:stone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stone_bricks>.addId(<resource:colouredstuff:stone_bricks_blue>);
-    <tag:blocks:skyfactory_5:coloured_stuff/chiseled_stone_bricks>.addId(<resource:colouredstuff:chiseled_stone_bricks_blue>);
-    <tag:blocks:skyfactory_5:coloured_stuff/dirt>.addId(<resource:colouredstuff:dirt_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/paths>.addId(<resource:colouredstuff:path_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/sandstone>.addId(<resource:colouredstuff:sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/cut_sandstone>.addId(<resource:colouredstuff:cut_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/smooth_sandstone>.addId(<resource:colouredstuff:smooth_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/chiseled_sandstone>.addId(<resource:colouredstuff:chiseled_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/bricks>.addId(<resource:colouredstuff:brick_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_planks>.addId(<resource:colouredstuff:slab_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_cobblestone>.addId(<resource:colouredstuff:slab_cobblestone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_stone>.addId(<resource:colouredstuff:slab_stone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_stone_bricks>.addId(<resource:colouredstuff:slab_stone_bricks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_sandstone>.addId(<resource:colouredstuff:slab_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/slab_bricks>.addId(<resource:colouredstuff:slab_brick_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_brick>.addId(<resource:colouredstuff:stairs_brick_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_planks>.addId(<resource:colouredstuff:stairs_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_stone>.addId(<resource:colouredstuff:stairs_stone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_cobblestone>.addId(<resource:colouredstuff:stairs_cobblestone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_sandstone>.addId(<resource:colouredstuff:stairs_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/stairs_stone_bricks>.addId(<resource:colouredstuff:stairs_stone_bricks_brown>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_stone>.addId(<resource:colouredstuff:wall_stone_magenta>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_sandstone>.addId(<resource:colouredstuff:wall_sandstone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_planks>.addId(<resource:colouredstuff:wall_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_cobblestone>.addId(<resource:colouredstuff:wall_cobblestone_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_stone_bricks>.addId(<resource:colouredstuff:wall_stone_bricks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/wall_bricks>.addId(<resource:colouredstuff:wall_brick_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/fence_planks>.addId(<resource:colouredstuff:fence_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/gate_planks>.addId(<resource:colouredstuff:gate_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/button_planks>.addId(<resource:colouredstuff:button_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/pressure_plate_planks>.addId(<resource:colouredstuff:pressure_plate_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/trapdoor_planks>.addId(<resource:colouredstuff:trapdoor_planks_${color}>);
-    <tag:blocks:skyfactory_5:coloured_stuff/door_planks>.addId(<resource:colouredstuff:door_planks_${color}>);
+// Tag additions
+<tag:items:forge:dusts/ender>.addId(<resource:thermal:ender_pearl_dust>);
+<tag:items:minecraft:pressure_plates>.addId(<resource:minecraft:stone_pressure_plate>);
+
+// Adds Crafting Tables to forge:workbench tag
+<tag:items:forge:workbench>.addId(<resource:enderio:painted_crafting_table>);
+<tag:items:forge:workbench>.addId(<resource:colouredstuff:crafting_table_none>);
+<tag:items:forge:workbench>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:crafting_table_${color}>));
+<tag:items:forge:workbench>.addId(<resource:minecraft:crafting_table>);
+<tag:items:forge:workbench>.addId(<resource:cyclic:workbench>);
+<tag:items:forge:workbench>.addId(<resource:craftingstation:crafting_station>);
+<tag:items:forge:workbench>.addId(<resource:craftingstation:crafting_station_slab>);
+
+// Using this as a test for goat spawns not working on this block normally
+<tag:blocks:minecraft:dirt>.addId(<resource:colouredstuff:dirt_none>);
+
+
+// Adding every block to the dragon immune tag
+for block in game.blocks {
+  <tag:blocks:minecraft:dragon_immune>.add(block);
 }
+
+
+// Tags each set of Coloured Stuff blocks
+
+<tag:blocks:skyfactory_5:coloured_stuff/crafting_tables>.addId(<resource:colouredstuff:crafting_table_rainbow>);
+
+<tag:blocks:skyfactory_5:coloured_stuff/logs>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:log_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wood>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wood_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/logs>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:log_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/log_stripped>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:log_stripped_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wood_stripped>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wood_stripped_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/crafting_tables>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:crafting_table_rainbow>));
+<tag:blocks:skyfactory_5:coloured_stuff/leaves>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:leaves_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/saplings>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:sapling_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/cobblestone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:cobblestone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stone_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stone_bricks_blue>));
+<tag:blocks:skyfactory_5:coloured_stuff/chiseled_stone_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:chiseled_stone_bricks_blue>));
+<tag:blocks:skyfactory_5:coloured_stuff/dirt>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:dirt_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/paths>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:path_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/cut_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:cut_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/smooth_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:smooth_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/chiseled_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:chiseled_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:brick_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_cobblestone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_cobblestone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_stone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_stone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_stone_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_stone_bricks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/slab_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:slab_brick_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_brick>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_brick_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_stone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_stone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_cobblestone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_cobblestone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/stairs_stone_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:stairs_stone_bricks_brown>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_stone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_stone_magenta>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_sandstone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_sandstone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_cobblestone>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_cobblestone_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_stone_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_stone_bricks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/wall_bricks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:wall_brick_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/fence_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:fence_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/gate_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:gate_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/button_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:button_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/pressure_plate_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:pressure_plate_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/trapdoor_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:trapdoor_planks_${color}>));
+<tag:blocks:skyfactory_5:coloured_stuff/door_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:door_planks_${color}>));

--- a/src/minecraft/scripts/tags.zs
+++ b/src/minecraft/scripts/tags.zs
@@ -423,45 +423,6 @@ for item in itemsToRemove {
 <tagmanager:items>.addId(<tag:items:forge:dusts/ender>, <resource:thermal:ender_pearl_dust>);
 <tagmanager:items>.addId(<tag:items:minecraft:pressure_plates>, <resource:minecraft:stone_pressure_plate>);
 
-// Ex Nihilo Sequentia
-// Crucibles
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:black_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:blue_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:brown_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:cyan_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:gray_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:green_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:light_blue_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:light_gray_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:lime_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:magenta_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:none_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:orange_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:pink_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:purple_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:red_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:white_crucible>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/crucibles>, <resource:exnihilocoloratus:yellow_crucible>);
-
-// Barrels
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:black_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:blue_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:brown_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:cyan_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:gray_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:green_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:light_blue_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:light_gray_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:lime_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:magenta_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:none_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:orange_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:pink_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:purple_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:red_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:white_barrel>);
-<tagmanager:items>.addId(<tag:items:exnihilosequentia/barrels>, <resource:exnihilocoloratus:yellow_barrel>);
-
 // Adds Crafting Tables to forge:workbench tag
 <tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:enderio:painted_crafting_table>);
 <tagmanager:items>.addId(<tag:items:forge:workbench>, <resource:colouredstuff:crafting_table_none>);

--- a/src/minecraft/scripts/tags/colors/black.zs
+++ b/src/minecraft/scripts/tags/colors/black.zs
@@ -1635,7 +1635,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/black>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/black>.addId(items);

--- a/src/minecraft/scripts/tags/colors/blue.zs
+++ b/src/minecraft/scripts/tags/colors/blue.zs
@@ -953,7 +953,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/blue>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/blue>.addId(items);

--- a/src/minecraft/scripts/tags/colors/brown.zs
+++ b/src/minecraft/scripts/tags/colors/brown.zs
@@ -3528,7 +3528,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/brown>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/brown>.addId(items);

--- a/src/minecraft/scripts/tags/colors/cyan.zs
+++ b/src/minecraft/scripts/tags/colors/cyan.zs
@@ -1387,7 +1387,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/cyan>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/cyan>.addId(items);

--- a/src/minecraft/scripts/tags/colors/gray.zs
+++ b/src/minecraft/scripts/tags/colors/gray.zs
@@ -1480,7 +1480,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/gray>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/gray>.addId(items);

--- a/src/minecraft/scripts/tags/colors/green.zs
+++ b/src/minecraft/scripts/tags/colors/green.zs
@@ -952,7 +952,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/green>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/green>.addId(items);

--- a/src/minecraft/scripts/tags/colors/light_blue.zs
+++ b/src/minecraft/scripts/tags/colors/light_blue.zs
@@ -864,7 +864,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/light_blue>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/light_blue>.addId(items);

--- a/src/minecraft/scripts/tags/colors/light_gray.zs
+++ b/src/minecraft/scripts/tags/colors/light_gray.zs
@@ -1308,7 +1308,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/light_gray>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/light_gray>.addId(items);

--- a/src/minecraft/scripts/tags/colors/lime.zs
+++ b/src/minecraft/scripts/tags/colors/lime.zs
@@ -617,7 +617,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/lime>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/lime>.addId(items);

--- a/src/minecraft/scripts/tags/colors/magenta.zs
+++ b/src/minecraft/scripts/tags/colors/magenta.zs
@@ -541,7 +541,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/magenta>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/magenta>.addId(items);

--- a/src/minecraft/scripts/tags/colors/none.zs
+++ b/src/minecraft/scripts/tags/colors/none.zs
@@ -149,7 +149,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/none>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/none>.addId(items);

--- a/src/minecraft/scripts/tags/colors/orange.zs
+++ b/src/minecraft/scripts/tags/colors/orange.zs
@@ -1501,7 +1501,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/orange>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/orange>.addId(items);

--- a/src/minecraft/scripts/tags/colors/pink.zs
+++ b/src/minecraft/scripts/tags/colors/pink.zs
@@ -1101,7 +1101,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/pink>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/pink>.addId(items);

--- a/src/minecraft/scripts/tags/colors/purple.zs
+++ b/src/minecraft/scripts/tags/colors/purple.zs
@@ -978,7 +978,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/purple>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/purple>.addId(items);

--- a/src/minecraft/scripts/tags/colors/red.zs
+++ b/src/minecraft/scripts/tags/colors/red.zs
@@ -1851,7 +1851,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/red>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/red>.addId(items);

--- a/src/minecraft/scripts/tags/colors/rgb.zs
+++ b/src/minecraft/scripts/tags/colors/rgb.zs
@@ -117,7 +117,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/rgb>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/rgb>.addId(items);

--- a/src/minecraft/scripts/tags/colors/white.zs
+++ b/src/minecraft/scripts/tags/colors/white.zs
@@ -1485,7 +1485,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/white>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/white>.addId(items);

--- a/src/minecraft/scripts/tags/colors/yellow.zs
+++ b/src/minecraft/scripts/tags/colors/yellow.zs
@@ -1747,7 +1747,5 @@ val items as ResourceLocation[] = [
   // GENERATOR END
 ];
 
-for item in items {
-  <tag:items:skyfactory_5:colored_items>.addId(item);
-  <tag:items:skyfactory_5:colored_items/yellow>.addId(item);
-}
+<tag:items:skyfactory_5:colored_items>.addId(items);
+<tag:items:skyfactory_5:colored_items/yellow>.addId(items);


### PR DESCRIPTION
CraftTweaker recalculates the backing tag map after each addId is called, using the varargs lets us make multiple changes before recalculating.

Also uses the tag directly instead of getting it from the tagmanager