### PR TITLE
Minor task reordering

### DIFF
--- a/src/minecraft/config/checklist/tasks.txt
+++ b/src/minecraft/config/checklist/tasks.txt
@@ -50,8 +50,8 @@ Use the Crafting Stick to make a Colorless Crafting Table
 Use a Barrel to create Dirt
 Eat Dirt!
 Use Colored Planks to craft any Color Crafting Table
-Use any Dye and a Stick to make a Color Torch
 Change the color of a Sapling by using Dye on it
+Use any Dye and a Stick to make a Color Torch
 Craft a Crafting Station to make recipes not available in the Color Crafting Tables
 Craft a Silent's Gear Sickle to break Leaves faster
 Craft a Silent's Gear Axe to break Wood faster


### PR DESCRIPTION
This pull request re-orders the tasks: "_recoloring of a sapling_" with "_coloring of a torch_" to decrease the chances of people using their last/only (green) dye on torches instead of on a sapling by moving the sapling dyeing task up one.