### PR TITLE
Add Sophisticated Storage blocks to Crafting Station blacklist

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingstation/tags/block_entity_type/blacklisted.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingstation/tags/block_entity_type/blacklisted.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,  
+  "values": ["sophisticatedstorage:barrel", "sophisticatedstorage:limited_barrel", "sophisticatedstorage:chest", "sophisticatedstorage:shulker_box", "sophisticatedstorage:controller", "sophisticatedstorage:storage_link", "sophisticatedstorage:storage_io", "sophisticatedstorage:storage_input", "sophisticatedstorage:storage_output"]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingstation/tags/block_entity_type/blacklisted.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingstation/tags/block_entity_type/blacklisted.json
@@ -1,4 +1,15 @@
 {
-  "replace": false,  
-  "values": ["sophisticatedstorage:barrel", "sophisticatedstorage:limited_barrel", "sophisticatedstorage:chest", "sophisticatedstorage:shulker_box", "sophisticatedstorage:controller", "sophisticatedstorage:storage_link", "sophisticatedstorage:storage_io", "sophisticatedstorage:storage_input", "sophisticatedstorage:storage_output"]
+  "replace": false,
+  "values": [
+    "sophisticatedstorage:barrel",
+    "sophisticatedstorage:limited_barrel",
+    "sophisticatedstorage:chest",
+    "sophisticatedstorage:shulker_box",
+    "sophisticatedstorage:controller",
+    "sophisticatedstorage:storage_link",
+    "sophisticatedstorage:storage_io",
+    "sophisticatedstorage:storage_input",
+    "sophisticatedstorage:storage_output",
+    "sophisticatedbackpacks:backpack"
+  ]
 }


### PR DESCRIPTION
Add Sophisticated Storage block entity types to `craftingstation:blacklisted` tag to stop it from interacting with them.