### PR TITLE
Adds missing mod advancement override files

### DIFF
--- a/src/minecraft/global_packs/required_data/advancement_removal/data/apotheosis/advancements/give_book.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/apotheosis/advancements/give_book.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/ars_nouveau/advancements/ritual_gravity.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/ars_nouveau/advancements/ritual_gravity.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/checklist/advancements/test/google.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/checklist/advancements/test/google.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/checklist/advancements/test/twitch.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/checklist/advancements/test/twitch.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_black.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_black.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_blue.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_blue.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_brown.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_brown.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_cyan.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_cyan.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_gray.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_gray.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_green.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_green.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_light_blue.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_light_blue.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_light_gray.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_light_gray.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_lime.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_lime.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_magenta.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_magenta.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_orange.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_orange.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_pink.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_pink.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_purple.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_purple.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_red.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_red.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_white.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_white.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_yellow.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/hammock_yellow.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/rope_and_nail.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/rope_and_nail.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_black.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_black.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_blue.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_blue.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_brown.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_brown.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_cyan.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_cyan.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_gray.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_gray.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_green.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_green.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_light_blue.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_light_blue.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_light_gray.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_light_gray.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_lime.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_lime.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_magenta.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_magenta.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_orange.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_orange.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_pink.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_pink.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_purple.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_purple.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_red.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_red.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_white.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_white.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_yellow.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/comforts/advancements/sleeping_bag_yellow.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/a_shower_experience.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/a_shower_experience.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/black_as_ink.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/black_as_ink.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/blazes_new_job.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/blazes_new_job.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/copiable_masterpiece.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/copiable_masterpiece.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/copiable_mystery.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/copiable_mystery.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/emerging_brand.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/emerging_brand.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experienced_engineer.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experienced_engineer.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experienced_recycler.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experienced_recycler.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experimental.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/experimental.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/gone_with_the_foil.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/gone_with_the_foil.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/great_publisher.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/great_publisher.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/relic_restoration.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/relic_restoration.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/spirit_taking.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/create_enchantment_industry/advancements/spirit_taking.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/culinaryconstruct/advancements/craft_culinary_food.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/culinaryconstruct/advancements/craft_culinary_food.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/adventure/rich.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/adventure/rich.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/adventure/richer.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/adventure/richer.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/place_capacitor_bank.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/enderio/advancements/place_capacitor_bank.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/activate_zombie_horse_trap.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/activate_zombie_horse_trap.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/complete_hide_and_seek_game.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/complete_hide_and_seek_game.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/it_bites.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/it_bites.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/kill_iceologer.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/kill_iceologer.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/kill_illusioner.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/kill_illusioner.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/summon_copper_golem.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/summon_copper_golem.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/the_magicians.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/adventure/the_magicians.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/beehive.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/beehive.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/shear_a_moobloom.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/shear_a_moobloom.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/tame_a_glare.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/husbandry/tame_a_glare.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/misc/yellow_dye_from_buttercup.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/misc/yellow_dye_from_buttercup.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/find_citadel.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/find_citadel.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/kill_wildfire.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/kill_wildfire.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/obtain_wildfire_crown.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/friendsandfoes/advancements/nether/obtain_wildfire_crown.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/glow_graffiti.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/glow_graffiti.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/glow_painting.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/glow_painting.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/graffiti.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/graffiti.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/painting.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/immersive_paintings/advancements/misc/painting.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/back_off_henry_jekyll.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/back_off_henry_jekyll.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/every_light_praises_the_master.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/every_light_praises_the_master.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/genie_what_are_you_doing_here.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/genie_what_are_you_doing_here.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/its_certainly_not_a_las_vegas_sphere_but_its_still_big.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/its_certainly_not_a_las_vegas_sphere_but_its_still_big.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/light_my_little_light_tell_me_do_i_shine_the_brightest_of_all.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/light_my_little_light_tell_me_do_i_shine_the_brightest_of_all.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/live_a_century_shine_a_century.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/live_a_century_shine_a_century.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/recipe_changer_light.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/recipe_changer_light.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/recipe_light_reflector.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/recipe_light_reflector.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/starcreft.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/starcreft.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/stop_mr_hyde.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/stop_mr_hyde.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/today_the_swamp_will_empty.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/lampcrafting/advancements/today_the_swamp_will_empty.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/budding_grapes.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/budding_grapes.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/cherry_picker.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/cherry_picker.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/forbidden_fruit.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/forbidden_fruit.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/fruits_of_the_field.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/fruits_of_the_field.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/grape_picker.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/grape_picker.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/juice_it_up.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/juice_it_up.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/juicy_success.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/juicy_success.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/mashy_success.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/mashy_success.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/nectar_of_life.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/nectar_of_life.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/overgrown_lattices.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/overgrown_lattices.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/purely_apple.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/purely_apple.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/sowing_the_future.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/sowing_the_future.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_first_press.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_first_press.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_magic_of_the_barrel.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_magic_of_the_barrel.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_noble_drop.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/the_noble_drop.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/vineyard_visionary.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/vineyard_visionary.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/vintage_perfection.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/vintage_perfection.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/wild_harvest.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/wild_harvest.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/wine_somelier.json
+++ b/src/minecraft/global_packs/required_data/advancement_removal/data/vinery/advancements/main/wine_somelier.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:barrier"
+    },
+    "title": {
+      "translate": "§kWaste of Time This is Intentional"
+    },
+    "description": {
+      "translate": "Yes"
+    },
+    "frame": "challenge",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true,
+    "background": "minecraft:textures/block/purple_concrete.png"
+  },
+  "criteria": {
+    "always": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}


### PR DESCRIPTION
Noticing a lot of people (including myself) that are still randomly getting Advancement tabs that shouldn't show up.

I wrote a PowerShell script to look through all the files inside of the mod jar files without extracting them to disk. The Script locates the path to all advancements that are not in a /recipies or /loot_table sub directory. It then creates a json override file from a template file in the correct sub folder of the advancement_removal data pack. 

I used one of the existing json files in the advacement_removal data pack as the template. 

The script found these 102 advancements that exist in the Mod Jar's but where not overridden to be impossible to acquire.

After adding these files to my game instance all of my glitched text advancement pages disappeared.