### PR TITLE
Fixes color sapling to orange and makes them smelting not blasting

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/smelting/color_apples_to_orange.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/smelting/color_apples_to_orange.json
@@ -1,7 +1,7 @@
 {
-  "type": "minecraft:blasting",
+  "type": "minecraft:smelting",
   "category": "misc",
-  "cookingtime": 100,
+  "cookingtime": 200,
   "experience": 0.0,
   "ingredient": {
     "tag": "skyfactory_5:color_apples"

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/smelting/color_saplings_to_orange.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/smelting/color_saplings_to_orange.json
@@ -1,10 +1,10 @@
 {
-  "type": "minecraft:blasting",
+  "type": "minecraft:smelting",
   "category": "misc",
-  "cookingtime": 100,
+  "cookingtime": 200,
   "experience": 0.0,
   "ingredient": {
-    "tag": "skyfactory_5:color_apples"
+    "tag": "skyfactory_5:color_saplings"
   },
-  "result": "sf5_things:orange_apple"
+  "result": "colouredstuff:sapling_orange"
 }


### PR DESCRIPTION
The sapling recipe was the same as apple.  I also switched them to smelting instead of blasting cause 1, they were in the smelting folder and 2, blasting is usually for ore type items. 