### PR TITLE
Remove Ugly Steel Plating

### DIFF
--- a/src/minecraft/config/silentgear-common.toml
+++ b/src/minecraft/config/silentgear-common.toml
@@ -31,19 +31,19 @@ azure = 64
 # Setting to zero would make the repair kit unusable.
 [item.repairKits.efficiency]
 # Range: 0.0 ~ 10.0
-very_crude = 0.30000001192092896
+very_crude = 0
 # Range: 0.0 ~ 10.0
-crude = 0.3499999940395355
+crude = 0
 # Range: 0.0 ~ 10.0
-sturdy = 0.4000000059604645
+sturdy = 0
 # Range: 0.0 ~ 10.0
-crimson = 0.44999998807907104
+crimson = 0
 # Range: 0.0 ~ 10.0
-azure = 0.5
+azure = 0
 # Repair efficiency with loose materials if no repair kit is used.
 # Setting a value greater than zero makes repair kits optional.
 # Range: 0.0 ~ 10.0
-missing = 0.0
+missing = 10
 
 [item.netherwood_charcoal]
 # Burn time of netherwood charcoal, in ticks. Vanilla charcoal is 1600.

--- a/src/minecraft/scripts/recipe_removals.zs
+++ b/src/minecraft/scripts/recipe_removals.zs
@@ -479,7 +479,10 @@ val items as IItemStack[] = [
   <item:occultism:raw_silver_block>,
 
   // Vein Creepers
-  <item:veincreeper:trap>
+  <item:veincreeper:trap>,
+
+  // Forbidden Smoothies
+  <item:forbiddensmoothies:ugly_steel_plating>
 
 ];
 


### PR DESCRIPTION
The Ugly Steel Plating is the Steel Plating from Forbidden Smoothies.
But Because of custom recipes it has no uses left, so it can be removed for unification and anticlutter.
Its also just incrediblely ugly.