### PR TITLE
Remove Ugly Steel Plating

### DIFF
--- a/src/minecraft/scripts/recipe_removals.zs
+++ b/src/minecraft/scripts/recipe_removals.zs
@@ -479,7 +479,10 @@ val items as IItemStack[] = [
   <item:occultism:raw_silver_block>,
 
   // Vein Creepers
-  <item:veincreeper:trap>
+  <item:veincreeper:trap>,
+
+  // Forbidden Smoothies
+  <item:forbiddensmoothies:ugly_steel_plating>
 
 ];
 


### PR DESCRIPTION
The Ugly Steel Plating is the Steel Plating from Forbidden Smoothies.
But Because of custom recipes it has no uses left, so it can be removed for unification and anticlutter.
Its also just incrediblely ugly.