### PR TITLE
Crude Fix for #123(Issue) (Silent Gear Arrow Still takes Demage)

### DIFF
--- a/src/minecraft/config/silentgear-common.toml
+++ b/src/minecraft/config/silentgear-common.toml
@@ -31,19 +31,19 @@ azure = 64
 # Setting to zero would make the repair kit unusable.
 [item.repairKits.efficiency]
 # Range: 0.0 ~ 10.0
-very_crude = 0.30000001192092896
+very_crude = 0
 # Range: 0.0 ~ 10.0
-crude = 0.3499999940395355
+crude = 0
 # Range: 0.0 ~ 10.0
-sturdy = 0.4000000059604645
+sturdy = 0
 # Range: 0.0 ~ 10.0
-crimson = 0.44999998807907104
+crimson = 0
 # Range: 0.0 ~ 10.0
-azure = 0.5
+azure = 0
 # Repair efficiency with loose materials if no repair kit is used.
 # Setting a value greater than zero makes repair kits optional.
 # Range: 0.0 ~ 10.0
-missing = 0.0
+missing = 10
 
 [item.netherwood_charcoal]
 # Burn time of netherwood charcoal, in ticks. Vanilla charcoal is 1600.

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/jei_info/silent_arrow.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/jei_info/silent_arrow.json
@@ -1,0 +1,8 @@
+{
+  "items": ["silentgear:arrow"],
+  "infos": [
+    {
+      "text": "NOT unbreakable, repair with main material directly"
+    }
+  ]
+}

--- a/src/minecraft/scripts/item_durability.zs
+++ b/src/minecraft/scripts/item_durability.zs
@@ -403,7 +403,6 @@ val itemsForUnbreakable = [
   <resource:silentgear:crossbow>,
   <resource:silentgear:slingshot>,
   <resource:silentgear:shield>,
-  <resource:silentgear:arrow>,
   <resource:silentgear:helmet>,
   <resource:silentgear:chestplate>,
   <resource:silentgear:leggings>,

--- a/src/minecraft/scripts/tooltips.zs
+++ b/src/minecraft/scripts/tooltips.zs
@@ -160,3 +160,7 @@ import crafttweaker.api.text.Component;
 // Mystical Agriculture
   var inferium_essence = Component.literal("Dropped from Lime Leaves").setStyle(<constant:formatting:yellow>);
   <item:mysticalagriculture:inferium_essence>.addTooltip(inferium_essence);
+
+// Silent Gear
+var arrow = Component.literal("NOT unbreakable, repair with main material directly").setStyle(<constant:formatting:yellow>);
+<item:silentgear:arrow>.addTooltip(arrow);


### PR DESCRIPTION
This is a **crude** fix for #123 
**This does not fix that problem directly**, it only elivaties the symptoms porblem somewhat.
It works by enableing repairing with a material directly, so that the arrow etleast can be repaired.
It also add incredible efficiency for repeairing directly.
It  adds a tooltip telling the player that arrows are not unbreable.
It removes the item from item_durability.zs as this adds the word unbreakeble in the tooltip which could lead to confusion as the item isnt acutally unbreakeble.
A better fix is not possible as silentgear has no option to disable ammo consumption.