### PR TITLE
Remove ways to get Silver from Occultism

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ars_ocultas/recipes/imbuement_silver_transmute.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ars_ocultas/recipes/imbuement_silver_transmute.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ars_ocultas/recipes/imbuement_silver_transmute.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ars_ocultas/recipes/imbuement_silver_transmute.json
@@ -1,7 +1,26 @@
 {
-  "conditions": [
+  "type": "ars_nouveau:imbuement",
+  "count": 1,
+  "input": {
+    "item": "minecraft:gold_ingot"
+  },
+  "output": "thermal:silver_ingot",
+  "pedestalItems": [
     {
-      "type": "forge:false"
+      "item": {
+        "item": "ars_nouveau:manipulation_essence"
+      }
+    },
+    {
+      "item": {
+        "item": "occultism:datura"
+      }
+    },
+    {
+      "item": {
+        "item": "occultism:spirit_attuned_gem"
+      }
     }
-  ]
+  ],
+  "source": 2000
 }

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot_from_dust.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot_from_dust.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot_from_raw.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/smelting/occultism/smelting/silver_ingot_from_raw.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}


### PR DESCRIPTION
This removes ways to get the silver from Occultism whoch is useless.
This also fixes #102 .

Btw/ This were my three first PR not only Sf5 but in general, i hope i dint mess up to bad.