### PR TITLE
Give thermal copper and electrum nuggets/ingots instead of create's

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/ochrum.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/ochrum.json
@@ -1,0 +1,23 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "create:ochrum"
+    }
+  ],
+  "results": [
+    {
+      "item": "create:crushed_raw_gold",
+      "chance": 0.2
+    },
+    {
+      "item": "minecraft:gold_nugget",
+      "chance": 0.2
+    },
+    {
+      "item": "thermal:electrum_nugget",
+      "chance": 0.2
+    }
+  ],
+  "processingTime": 250
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/ochrum_recycling.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/ochrum_recycling.json
@@ -1,0 +1,23 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "create:stone_types/ochrum"
+    }
+  ],
+  "results": [
+    {
+      "item": "create:crushed_raw_gold",
+      "chance": 0.2
+    },
+    {
+      "item": "minecraft:gold_nugget",
+      "chance": 0.2
+    },
+    {
+      "item": "thermal:electrum_nugget",
+      "chance": 0.2
+    }
+  ],
+  "processingTime": 250
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/tuff.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/tuff.json
@@ -1,0 +1,35 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "minecraft:tuff"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:flint",
+      "chance": 0.25
+    },
+    {
+      "item": "minecraft:gold_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "thermal:copper_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "create:zinc_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:iron_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "thermal:electrum_nugget",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 350
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/tuff_recycling.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/tuff_recycling.json
@@ -1,0 +1,35 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "create:stone_types/tuff"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:flint",
+      "chance": 0.25
+    },
+    {
+      "item": "minecraft:gold_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "thermal:copper_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "create:zinc_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:iron_nugget",
+      "chance": 0.1
+    },
+    {
+      "item": "thermal:electrum_nugget",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 350
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/veridium.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/veridium.json
@@ -1,0 +1,19 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "create:veridium"
+    }
+  ],
+  "processingTime": 250,
+  "results": [
+    {
+      "chance": 0.8,
+      "item": "create:crushed_raw_copper"
+    },
+    {
+      "chance": 0.8,
+      "item": "thermal:copper_nugget"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/veridium_recycling.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/crushing/veridium_recycling.json
@@ -1,0 +1,19 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "create:stone_types/veridium"
+    }
+  ],
+  "processingTime": 250,
+  "results": [
+    {
+      "chance": 0.8,
+      "item": "create:crushed_raw_copper"
+    },
+    {
+      "chance": 0.8,
+      "item": "thermal:copper_nugget"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/splashing/crushed_raw_copper.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/create/recipes/splashing/crushed_raw_copper.json
@@ -1,0 +1,18 @@
+{
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "item": "create:crushed_raw_copper"
+    }
+  ],
+  "results": [
+    {
+      "count": 9,
+      "item": "thermal:copper_nugget"
+    },
+    {
+      "chance": 0.5,
+      "item": "minecraft:clay_ball"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/createaddition/recipes/mixing/electrum.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/createaddition/recipes/mixing/electrum.json
@@ -1,0 +1,27 @@
+{
+  "type": "create:mixing",
+  "ingredients": [
+    {
+      "tag": "forge:ingots/gold"
+    },
+    {
+      "tag": "forge:ingots/silver"
+    }
+  ],
+  "results": [
+    {
+      "item": "thermal:electrum_ingot",
+      "count": 2
+    }
+  ],
+  "heatRequirement": "heated",
+  "conditions": [
+    {
+      "type": "forge:not",
+      "value": {
+        "type": "forge:tag_empty",
+        "tag": "forge:ingots/silver"
+      }
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/thermal/recipes/compat/create/pulverizer_create_veridium.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/thermal/recipes/compat/create/pulverizer_create_veridium.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:pulverizer",
+  "ingredient": {
+    "item": "create:veridium"
+  },
+  "result": [
+    {
+      "item": "create:crushed_raw_copper",
+      "chance": 0.8
+    },
+    {
+      "item": "thermal:copper_nugget",
+      "chance": 0.8
+    }
+  ],
+  "conditions": [
+    {
+      "type": "thermal:flag",
+      "flag": "mod_create"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/thermal/recipes/compat/create/pulverizer_create_veridium_recycle.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/thermal/recipes/compat/create/pulverizer_create_veridium_recycle.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:pulverizer_recycle",
+  "ingredient": {
+    "tag": "create:stone_types/veridium"
+  },
+  "result": [
+    {
+      "item": "create:crushed_raw_copper",
+      "chance": 0.8
+    },
+    {
+      "item": "thermal:copper_nugget",
+      "chance": 0.8
+    }
+  ],
+  "conditions": [
+    {
+      "type": "thermal:flag",
+      "flag": "mod_create"
+    }
+  ]
+}


### PR DESCRIPTION
This fixes a couple of recipes for crushing, washing, mixing and pulverizing:
`create:copper_nugget` -> `thermal:copper_nugget`
`createaddition:electrum_nugget` -> `thermal:electrum_nugget`
`createaddition:electrum_ingot` -> `thermal:electrum_ingot`