### PR TITLE
Fixes sand and glowstone using the same dye recipe

### DIFF
--- a/src/minecraft/scripts/resources/stone_blocks.zs
+++ b/src/minecraft/scripts/resources/stone_blocks.zs
@@ -25,7 +25,7 @@ craftingTable.addShapeless(
 craftingTable.addShapeless(
   "sand_from_dye",
   <item:minecraft:sand>,
-  [<tag:items:forge:dyes/brown>, <tag:items:forge:dyes/brown>, <tag:items:forge:dyes/orange>, <tag:items:forge:dyes/orange>]
+  [<tag:items:forge:dyes/brown>, <tag:items:forge:dyes/orange>, <tag:items:forge:dyes/orange>, <tag:items:forge:dyes/orange>]
 );
 
 // Obsidian


### PR DESCRIPTION
Sand now uses 1 brown 3 orange, instead of 2 of each dye.