### PR TITLE
Remove Nether Portal and add Painting Tooltip

### DIFF
--- a/src/minecraft/config/dimpaintings-common.toml
+++ b/src/minecraft/config/dimpaintings-common.toml
@@ -11,4 +11,4 @@ netherMaxY = 72
 # Range: > 0
 teleportCooldown = 4
 # Disable nether portal creation (Default: false)
-disableNetherPortal = false
+disableNetherPortal = true

--- a/src/minecraft/scripts/tooltips.zs
+++ b/src/minecraft/scripts/tooltips.zs
@@ -182,7 +182,12 @@ var boss_mob_gateway = Component.literal("Warning! Summons a Boss Mob").setStyle
 
 // Ugly Steel Plating
 var ugly_steel_plating = Component.literal("Covers Blenders & Printers to save FPS").setStyle(<constant:formatting:yellow>);
-  <item:forbiddensmoothies:ugly_steel_plating>.addTooltip(ugly_steel_plating);
+<item:forbiddensmoothies:ugly_steel_plating>.addTooltip(ugly_steel_plating);
 
+// Dimension Painting
+var dimension_painting = Component.literal("Teleports to you to its specified Dimension").setStyle(<constant:formatting:yellow>);
+<item:dimpaintings:end_painting>.addTooltip(dimension_painting);
+<item:dimpaintings:nether_painting>.addTooltip(dimension_painting);
+<item:dimpaintings:overworld_painting>.addTooltip(dimension_painting);
 
 // var tool_belt_tip = Component.translatable("some.lang.key").setStyle(<constant:formatting:gold>);


### PR DESCRIPTION
This adds a tooltip to the dimpaintings since players might thing that theese are just useless paintings.
The No Nether Portal Mod should also be added:
https://www.curseforge.com/minecraft/mc-mods/nonetherportal
But Darkosto needs to add it himself