### PR TITLE
Adds limbs heads to forge:heads tag for Ender IO Slice N Splice

### DIFF
--- a/src/minecraft/global_packs/required_data/tag_unification/data/forge/tags/items/heads.json
+++ b/src/minecraft/global_packs/required_data/tag_unification/data/forge/tags/items/heads.json
@@ -61,7 +61,17 @@
     "#forge:heads/wolf",
     "#forge:heads/zoglin",
     "#forge:heads/zombie_villager",
-    "#forge:heads/zombified_piglin"
+    "#forge:heads/zombified_piglin",
+    "limbs:drowned_head",
+    "limbs:enderman_head",
+    "limbs:husk_head",
+    "limbs:piglin_brute_head",
+    "limbs:piglin_head",
+    "limbs:skeleton_head",
+    "limbs:stray_head",
+    "limbs:wither_skeleton_head",
+    "limbs:zombie_head",
+    "limbs:zombified_piglin_head"
   ],
   "replace": true
 }


### PR DESCRIPTION
Ender IO's Slice 'N' Splice calls the `forge:head` tag for its recipe, this adds the heads from limbs to the tag. Fixes #161 