### PR TITLE
add automatic labelling to feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/---feature-request-form.yml
+++ b/.github/ISSUE_TEMPLATE/---feature-request-form.yml
@@ -1,6 +1,6 @@
 name: "Feature Request"
 description: "Suggest a mod or a change to the config or scripts"
-labels: ["Feature Request"]
+labels: ["enhancement"]
 assignees:
   - Darkosto
 body:


### PR DESCRIPTION
I noticed that only your bug reports get auto-labeled, and the feature requests are set to *try* to auto-label using a non-existing label name. So ive changed it to use the label already provided for feature requests.