### PR TITLE
Fix recipe conflict bulk stick crafting and grapevine stems

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/vinery/recipes/grapevine_stem.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/vinery/recipes/grapevine_stem.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "grapevine_stem",
+  "pattern": ["#", "#"],
+  "key": {
+    "#": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "vinery:grapevine_stem",
+    "count": 1
+  }
+}


### PR DESCRIPTION
Changes grapevine stems recipe to use 2 sticks instead of 2 logs, output adjusted to give 1 grapevine stem.