### PR TITLE
Fix InventorySorter potentially voiding items in curios slots

### DIFF
--- a/src/minecraft/defaultconfigs/inventorysorter-server.toml
+++ b/src/minecraft/defaultconfigs/inventorysorter-server.toml
@@ -3,4 +3,7 @@
 # Container blacklist
 containerBlacklist = []
 # Slot type blacklist
-slotBlacklist = ["top.theillusivec4.curios.common.inventory.CurioSlot"]
+slotBlacklist = [
+  "top.theillusivec4.curios.common.inventory.CurioSlot",
+  "tfar.craftingstation.slot.BigSlot"
+]

--- a/src/minecraft/defaultconfigs/inventorysorter-server.toml
+++ b/src/minecraft/defaultconfigs/inventorysorter-server.toml
@@ -3,4 +3,4 @@
 # Container blacklist
 containerBlacklist = []
 # Slot type blacklist
-slotBlacklist = []
+slotBlacklist = ["top.theillusivec4.curios.common.inventory.CurioSlot"]


### PR DESCRIPTION
When hitting the InventorySorter's keybind in/on curios slots it can potentially voids things like items or even backpacks, this disables it from doing anything in these slots.