### PR TITLE
Block Refurbished Furniture from Carryon

### DIFF
--- a/src/minecraft/config/carryon-common.toml
+++ b/src/minecraft/config/carryon-common.toml
@@ -360,7 +360,8 @@ forbiddenTiles = [
   "enderio:redstone_conduit",
   "enderio:item_conduit",
   "enderio:dense_me_conduit",
-  "enderio:me_conduit"
+  "enderio:me_conduit",
+  "refurbished_furniture:*"
 ]
 # Entities that cannot be picked up
 forbiddenEntities = [


### PR DESCRIPTION
Refurbished Furniture needs to be removed form Carryon beacause almost all of the block from it just break when carrying them on:
 The Elecricity Links break for example or two block wide blocks get splitted.