### PR TITLE
Remove Charger T4

### DIFF
--- a/src/minecraft/config/jei/blacklist.cfg
+++ b/src/minecraft/config/jei/blacklist.cfg
@@ -2019,3 +2019,4 @@ occultism:silver_block
 occultism:raw_silver_block
 occultism:silver_ore
 occultism:silver_ore_deepslate
+chargers:charger_t4

--- a/src/minecraft/scripts/recipe_removals.zs
+++ b/src/minecraft/scripts/recipe_removals.zs
@@ -483,8 +483,10 @@ val items as IItemStack[] = [
   <item:occultism:raw_silver_block>,
 
   // Vein Creepers
-  <item:veincreeper:trap>
+  <item:veincreeper:trap>,
 
+  // Chargers
+  <item:chargers:charger_t4>
 ];
 
 for item in items {


### PR DESCRIPTION
This PR removed the Charger T4 as it has a capacity of half of a java long meaning that just two of these replace an entire T8 Draconil Ball.
