### PR TITLE
Fix Zombified Piglins not being counted towards the Pink Trophies advancement

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/advancements/tracking_advancements/trophies/pink_trophies.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/advancements/tracking_advancements/trophies/pink_trophies.json
@@ -153,7 +153,7 @@
         "items": [
           {
             "items": ["obtrophies:trophy"],
-            "nbt": "{BlockEntityTag:{SpecialCycleVariant:0b,VariantID:0b,entity:\"earthmobsmod:zombified_piglin\"}}"
+            "nbt": "{BlockEntityTag:{SpecialCycleVariant:0b,VariantID:0b,entity:\"minecraft:zombified_piglin\"}}"
           }
         ]
       }


### PR DESCRIPTION
Should fix #214
Seems like this only works if you get a brand new trophy from a gate, probably intended design by Darkosto