### PR TITLE
Fix Item Duplication with Little Logistics

### DIFF
--- a/src/minecraft/config/carryon-common.toml
+++ b/src/minecraft/config/carryon-common.toml
@@ -387,7 +387,8 @@ forbiddenEntities = [
   "taterzens:npc",
   "easy_npc:*",
   "bodiesbodies:dead_body",
-  "luggage:*"
+  "luggage:*",
+  "littlelogistics:*"
 ]
 # Entities that cannot have other entities stacked on top of them
 forbiddenStacking = ["minecraft:horse"]


### PR DESCRIPTION
This fixies an item duplication bug with Little Logistics.
When you carryon any entity from it, the contents of the enity are dropped, but the contents are still in the entity.

https://github.com/user-attachments/assets/37572416-ab82-434e-a7e4-b40198bd0e8d

