### PR TITLE
Fixes lychee recipe for prosperity shards when dye sinks into soul sand

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prosperity_shards_below_soul_fire.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prosperity_shards_below_soul_fire.json
@@ -1,0 +1,27 @@
+{
+  "type": "lychee:item_inside",
+  "hide_in_viewer": true,
+  "contextual": [
+    {
+      "type": "location",
+      "offsetY": 1,
+      "predicate": {
+        "block": {
+          "blocks": ["minecraft:soul_fire"]
+        }
+      }
+    }
+  ],
+  "item_in": {
+    "item": "minecraft:light_blue_dye"
+  },
+  "block_in": {
+    "blocks": ["minecraft:soul_sand"]
+  },
+  "post": [
+    {
+      "type": "drop_item",
+      "item": "mysticalagriculture:prosperity_shard"
+    }
+  ]
+}


### PR DESCRIPTION
The conversion of light blue dye to prosperity shards when soul sand is used is currently inconsistent, as the item could fall below the soul fire.
This PR adds a hidden lychee recipe (meaning it doesn't show up in JEI) for item in soul_sand with soul_fire above it, fixing the issue.