### PR TITLE
Fix to make IE Accumulator recipes show up in JEI correctly

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_hv.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_hv.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "a": { "tag": "forge:plates/aluminum" },
+    "c": { "tag": "forge:ingots/hop_graphite" },
+    "e": { "item": "immersiveengineering:redstone_acid" },
+    "f": { "tag": "forge:ingots/steel" },
+    "w": { "tag": "forge:treated_wood" }
+  },
+  "pattern": ["waw", "fef", "wcw"],
+  "result": { "item": "immersiveengineering:capacitor_hv" },
+  "show_notification": true
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_lv.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_lv.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "a": { "tag": "forge:plates/lead" },
+    "e": { "item": "immersiveengineering:redstone_acid" },
+    "f": { "tag": "forge:ingots/iron" },
+    "w": { "tag": "forge:treated_wood" }
+  },
+  "pattern": ["waw", "fef", "waw"],
+  "result": { "item": "immersiveengineering:capacitor_lv" },
+  "show_notification": true
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_mv.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/immersiveengineering/recipes/crafting/capacitor_mv.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "a": { "tag": "forge:plates/nickel" },
+    "c": { "tag": "forge:plates/iron" },
+    "e": { "item": "immersiveengineering:redstone_acid" },
+    "f": { "tag": "forge:ingots/steel" },
+    "w": { "tag": "forge:treated_wood" }
+  },
+  "pattern": ["waw", "fef", "wcw"],
+  "result": { "item": "immersiveengineering:capacitor_mv" },
+  "show_notification": true
+}


### PR DESCRIPTION
Fixes the last recipes using: `{"type":"immersiveengineering:fluid","amount":1000,"tag":"forge:FLUID"}` that did not show up in JEI correctly, this probably needs a proper fix to make these recipes work with the jerrycan and other types of buckets.