### PR TITLE
Hide Miner's Light

### DIFF
--- a/src/minecraft/config/jei/blacklist.cfg
+++ b/src/minecraft/config/jei/blacklist.cfg
@@ -2019,3 +2019,4 @@ occultism:silver_block
 occultism:raw_silver_block
 occultism:silver_ore
 occultism:silver_ore_deepslate
+mininggadgets:minerslight


### PR DESCRIPTION
Hides Miners Light in jei as it has no texture in jei and can only be places by other item form Minining Gadets.