### PR TITLE
Add more seeds from dye recipes, pumpkins and thermal seeds.

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingforblockheads/craftingforblockheads/plants_and_seed_resources.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/craftingforblockheads/craftingforblockheads/plants_and_seed_resources.json
@@ -19,27 +19,13 @@
         "item": "exnihilosequentia:grass_seeds"
       },
       "includes": [
-        {
-          "item": "exnihilosequentia:grass_seeds"
-        },
-        {
-          "item": "minecraft:sugar_cane"
-        },
-        {
-          "item": "minecraft:bamboo"
-        },
-        {
-          "item": "minecraft:kelp"
-        },
-        {
-          "item": "exnihilosequentia:mycelium_spores"
-        },
-        {
-          "item": "exnihilosequentia:crimson_nylium_spores"
-        },
-        {
-          "item": "exnihilosequentia:warped_nylium_spores"
-        },
+        { "item": "exnihilosequentia:grass_seeds" },
+        { "item": "minecraft:sugar_cane" },
+        { "item": "minecraft:bamboo" },
+        { "item": "minecraft:kelp" },
+        { "item": "exnihilosequentia:mycelium_spores" },
+        { "item": "exnihilosequentia:crimson_nylium_spores" },
+        { "item": "exnihilosequentia:warped_nylium_spores" },
         { "item": "sushigocrafting:cucumber_seeds" },
         { "item": "thermal:corn_seeds" },
         { "item": "immersiveengineering:seed" },
@@ -47,7 +33,17 @@
         { "item": "thermal:bell_pepper_seeds" },
         { "item": "thermal:eggplant_seeds" },
         { "item": "thermal:tomato_seeds" },
-        { "item": "thermal:flax_seeds" }
+        { "item": "thermal:flax_seeds" },
+        { "item": "thermal:sadiroot_seeds" },
+        { "item": "minecraft:pumpkin_seeds" },
+        { "item": "thermal:amaranth_seeds" },
+        { "item": "thermal:strawberry_seeds" },
+        { "item": "thermal:barley_seeds" },
+        { "item": "thermal:radish_seeds" },
+        { "item": "thermal:rice_seeds" },
+        { "item": "thermal:spinach_seeds" },
+        { "item": "thermal:green_bean_seeds" },
+        { "item": "thermal:peanut_seeds" }
       ],
       "soft_requirements": ["vanilla_composter_present"],
       "hard_requirements": ["colored_crafting_table_present"],

--- a/src/minecraft/scripts/resources/seeds.zs
+++ b/src/minecraft/scripts/resources/seeds.zs
@@ -126,8 +126,72 @@ craftingTable.addShapeless(
   [<tag:items:forge:dyes/brown>, <tag:items:forge:dyes/brown>, <tag:items:forge:dyes/green>]
 );
 
+// Sadiroot Seeds
+craftingTable.addShapeless(
+  "sadiroot_seeds_from_dye",
+  <item:thermal:sadiroot_seeds>,
+  [<tag:items:forge:dyes/cyan>, <tag:items:forge:dyes/cyan>, <tag:items:forge:dyes/light_blue>]
+);
 
+// Pumpkin Seeds
+craftingTable.addShapeless(
+  "pumpkin_seeds_from_dye",
+  <item:minecraft:pumpkin_seeds>,
+  [<tag:items:forge:dyes/yellow>, <tag:items:forge:dyes/yellow>, <tag:items:forge:dyes/orange>]
+);
 
+// Amaranth Seeds
+craftingTable.addShapeless(
+  "amaranth_seeds_from_dye",
+  <item:thermal:amaranth_seeds>,
+  [<tag:items:forge:dyes/brown>, <tag:items:forge:dyes/brown>, <tag:items:forge:dyes/red>]
+);
 
+// Strawberry Seeds
+craftingTable.addShapeless(
+  "strawberry_seeds_from_dye",
+  <item:thermal:strawberry_seeds>,
+  [<tag:items:forge:dyes/red>, <tag:items:forge:dyes/red>, <tag:items:forge:dyes/green>]
+);
 
+// Barley Seeds
+craftingTable.addShapeless(
+  "barley_seeds_from_dye",
+  <item:thermal:barley_seeds>,
+  [<tag:items:forge:dyes/brown>, <tag:items:forge:dyes/brown>, <tag:items:forge:dyes/yellow>]
+);
 
+// Radish Seeds
+craftingTable.addShapeless(
+  "radish_seeds_from_dye",
+  <item:thermal:radish_seeds>,
+  [<tag:items:forge:dyes/red>, <tag:items:forge:dyes/lime>, <tag:items:forge:dyes/brown>]
+);
+
+// Rice Seeds
+craftingTable.addShapeless(
+  "rice_seeds_from_dye",
+  <item:thermal:rice_seeds>,
+  [<tag:items:forge:dyes/white>, <tag:items:forge:dyes/white>, <tag:items:forge:dyes/yellow>]
+);
+
+// Spinach Seeds
+craftingTable.addShapeless(
+  "spinach_seeds_from_dye",
+  <item:thermal:spinach_seeds>,
+  [<tag:items:forge:dyes/green>, <tag:items:forge:dyes/green>, <tag:items:forge:dyes/gray>]
+);
+
+// Green Bean Seeds
+craftingTable.addShapeless(
+  "green_bean_seeds_from_dye",
+  <item:thermal:green_bean_seeds>,
+  [<tag:items:forge:dyes/green>, <tag:items:forge:dyes/green>, <tag:items:forge:dyes/light_gray>]
+);
+
+// Peanut Seeds
+craftingTable.addShapeless(
+  "peanut_seeds_from_dye",
+  <item:thermal:peanut_seeds>,
+  [<tag:items:forge:dyes/yellow>, <tag:items:forge:dyes/yellow>, <tag:items:forge:dyes/red>]
+);


### PR DESCRIPTION
Also included these into the `Farming Items` from craftingforblockheads.
(If there were already intended ways to get some of these or if you have other suggestions, let me know)
### Added:
```
minecraft:pumpkin_seeds
thermal:sadiroot_seeds
thermal:amaranth_seeds
thermal:strawberry_seeds
thermal:barley_seeds
thermal:radish_seeds
thermal:rice_seeds
thermal:spinach_seeds
thermal:green_bean_seeds
thermal:peanut_seeds
```
I've attempted to keep these close to their color, firstly the dye their "crop" might grind into, secondly the color of the seed's tooltip and finally the texture of the item.
![2025-01-11_00 26 31](https://github.com/user-attachments/assets/b4af8538-fb60-4a57-923d-d4e85217320c)
![2025-01-11_00 26 35](https://github.com/user-attachments/assets/e8ef4b29-da9f-4d8f-8d34-c168039d7231)
![2025-01-11_00 26 41](https://github.com/user-attachments/assets/26f31fb7-daad-4cee-945b-bcef2b2a31ef)
![2025-01-11_00 26 48](https://github.com/user-attachments/assets/7d16cc12-fe9a-40fd-9842-e632dbbb95eb)
![2025-01-11_00 26 52](https://github.com/user-attachments/assets/6122ed4d-ddd5-4b31-a0d0-b90d1250ead1)
![2025-01-11_00 27 19](https://github.com/user-attachments/assets/5f360f58-198e-45a1-8140-a9b8147b4d3a)
![2025-01-11_00 27 24](https://github.com/user-attachments/assets/c7a1ee2f-c8d8-4746-8fde-f61782aa92a6)
![2025-01-11_00 27 32](https://github.com/user-attachments/assets/01bdd5d4-371b-495e-8eb0-8b1e3e624ac9)
![2025-01-11_00 27 46](https://github.com/user-attachments/assets/3e5022a1-5423-4742-af6c-a3b25e0d3af1)

### Not Included, in this:
```
thermal:hops_seeds
thermal:tea_seeds
thermal:frost_melon_seeds
```
These either have no functional use (only for green dye), or are oddball, the frost melon block does not show up in JEI, but I can include them if needed/wanted/