### PR TITLE
Add Inferium Seeds tags to the Mystical Customization crops

### DIFF
--- a/src/minecraft/scripts/tags.zs
+++ b/src/minecraft/scripts/tags.zs
@@ -516,3 +516,34 @@ for block in game.blocks {
 <tag:blocks:skyfactory_5:coloured_stuff/pressure_plate_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:pressure_plate_planks_${color}>));
 <tag:blocks:skyfactory_5:coloured_stuff/trapdoor_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:trapdoor_planks_${color}>));
 <tag:blocks:skyfactory_5:coloured_stuff/door_planks>.addId(colors.map<ResourceLocation>(color => <resource:colouredstuff:door_planks_${color}>));
+
+// Add necessary tags to Mystical Customization crops, since there seems to be no real way to do it
+
+var cropColors = [
+    "black",
+    "blue",
+    "brown",
+    "cyan",
+    "gray",
+    "green",
+    "light_blue",
+    "light_gray",
+    "lime",
+    "magenta",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "white",
+    "yellow",
+    "none",
+    "rgb"
+];
+
+<tag:blocks:forge:mineable/sickle>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:cucumber:mineable/sickle>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:minecraft:sword_efficient>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:minecraft:crops>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:mysticalagriculture:crops>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:minecraft:bee_growables>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));
+<tag:blocks:ae2:growth_acceleratable>.addId(cropColors.map<ResourceLocation>(color => <resource:mysticalagriculture:${color}_crop_crop>));


### PR DESCRIPTION
Adds the following tags to the Mystical Customization crops to be consistent with Inferium Seeds
`#forge:mineable/sickle`
`#cucumber:mineable/sickle`
`#minecraft:sword_efficient`
`#minecraft:crops`
`#mysticalagriculture:crops`
`#minecraft:bee_growables`
`#ae2:growth_acceleratable`

This change allows alternative crop growing methods that work on Inferium Seeds such as Sprinklers, the Growth enchant, and other crop accelerators.
![image](https://github.com/user-attachments/assets/206814d7-58ea-45ff-9fbb-efeb4b36c5fe)
