### PR TITLE
Remove Duplicate Glow Ink Recipie for Crushing Macerator

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/cyclic/recipes/crusher/glow_ink_sack.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/cyclic/recipes/crusher/glow_ink_sack.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/8ddc3dce-4100-45fc-ab0d-49d9b9e3a6ff)
Removes the Glowstone one.