### PR TITLE
Remove BHC Molten Heart Alloy Smelter recipies

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/blue_heart_melted.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/blue_heart_melted.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/green_heart_melted.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/green_heart_melted.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/yellow_heart_melted.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/bhc/recipes/smelting/yellow_heart_melted.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}


### PR DESCRIPTION
Removes Baubley Hearts Container Molten Heart Alloy Smelter recipies, because  molten hearts are disabled.
![grafik](https://github.com/user-attachments/assets/054fe412-6dd6-4364-b72f-4626b2a4542c)
