### PR TITLE
Hide Generalized Predictions

### DIFF
--- a/src/minecraft/config/jei/blacklist.cfg
+++ b/src/minecraft/config/jei/blacklist.cfg
@@ -2034,3 +2034,6 @@ mininggadgets:minerslight
 ae2:ender_dust
 enderio:powered_spawner
 industrialforegoing:mob_duplicator
+hostilenetworks:overworld_prediction
+hostilenetworks:nether_prediction
+hostilenetworks:end_prediction


### PR DESCRIPTION
Hides Generelized Predictions in JEI as there is no way to get them.
Their uses do not have to be disabled as their is no way to get them.
Fixes #137.