### PR TITLE
Remove Fluix Tools Recipies

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_axe.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_axe.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_hoe.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_hoe.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_pickaxe.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_pickaxe.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_shovel.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_shovel.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_sword.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/ae2/recipes/tools/fluix_sword.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}


### PR DESCRIPTION
Removes Fluix Tool Recipie, because they are disabled.
![grafik](https://github.com/user-attachments/assets/ced90757-268a-4810-b4e6-e0236c642e0c)
