### PR TITLE
Fix Colorless Water Melting Chamber conflict.

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/colouredstuff/recipes/cyclic/melt_none.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/colouredstuff/recipes/cyclic/melt_none.json
@@ -1,0 +1,25 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "item": "minecraft:feather"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_none",
+    "count": 250
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/colouredstuff/recipes/cyclic/melt_none_2x.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/colouredstuff/recipes/cyclic/melt_none_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "item": "minecraft:feather"
+  },{
+    "item": "minecraft:feather"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_none",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}


### PR DESCRIPTION
Colorless Water:
![grafik](https://github.com/user-attachments/assets/df7071b4-8783-4731-a9a7-1d57a446844f)
Liquid Wax:
![grafik](https://github.com/user-attachments/assets/bbc009fc-987f-4056-a9b1-c455396c8c15)

Normally Colorless Water uses everything with the dyes/none tag which includes honeycombs and feathers but the honeycombs cause a duplicate recipie so i changed to only accepting feathers.
It also changes the 2x recipie which has no duplicates to not cause confusion.