### PR TITLE
Fixes red titan gateway advancement for cluckshroom

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/advancements/tracking_advancements/titan_gateways/red_titan_gateways.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/advancements/tracking_advancements/titan_gateways/red_titan_gateways.json
@@ -21,7 +21,7 @@
         "items": [
           {
             "items": ["gateways:gate_pearl"],
-            "nbt": "{gateway:\"gateways:normal/cluck_shroom\"}"
+            "nbt": "{gateway:\"gateways:normal/cluckshroom\"}"
           }
         ]
       }


### PR DESCRIPTION
When you get a `Cluckshroom Gateway` or a `Titan Cluckshroom Gateway`, it doesn't count for the red titan gateway advancement.

I suspect this PR will fix it as it looks like the nbt value had a typo. I haven't test this fix though.