### PR TITLE
Disable Vinery Apple Press from being picked up by CarryOn

### DIFF
--- a/src/minecraft/config/carryon-common.toml
+++ b/src/minecraft/config/carryon-common.toml
@@ -367,7 +367,8 @@ forbiddenTiles = [
   "enderio:dense_me_conduit",
   "enderio:me_conduit",
   "refurbished_furniture:*",
-  "draconicevolution:*"
+  "draconicevolution:*",
+  "vinery:apple_press"
 ]
 # Entities that cannot be picked up
 forbiddenEntities = [


### PR DESCRIPTION
As this breaks the rendering for the Apple Press.