### PR TITLE
Firework Star Catalyst changes

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/thermal_recipes/catalysts/catalyst_firework_charge.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/thermal_recipes/catalysts/catalyst_firework_charge.json
@@ -3,9 +3,9 @@
   "ingredient": {
     "item": "minecraft:firework_star"
   },
-  "primary_mod": 6.66,
-  "secondary_mod": 0.75,
-  "energy_mod": 1.25,
+  "primary_mod": 3.33,
+  "secondary_mod": 0.5,
+  "energy_mod": 1.5,
   "min_chance": 0.2,
-  "use_chance": 0.85
+  "use_chance": 0.99
 }

--- a/src/minecraft/scripts/shapeless_recipes.zs
+++ b/src/minecraft/scripts/shapeless_recipes.zs
@@ -544,3 +544,10 @@ craftingTable.addShapeless(
   <item:sf5_things:block_of_green_dye> * 3,
   [<item:sf5_things:block_of_blue_dye>, <item:sf5_things:block_of_yellow_dye>, <item:sf5_things:block_of_green_dye>]
 );
+
+// Blank Firework Star (Pulverizer Catalyst)
+  craftingTable.addShapeless(
+  "fire_charge_to_firework_star",
+  <item:minecraft:firework_star>,
+  [<item:minecraft:gunpowder>, <item:minecraft:fire_charge>]
+);


### PR DESCRIPTION
Added recipe for currently unobtainable firework star (that has no nbt), as the pulverizer does not accept ones vanilla lets your craft.
Also nerfed primary mod, from ~6x to ~3x, this is still really powerful from my testing.