### PR TITLE
Swapped the ingredients required for 2 of the netherite tier upgrades as they didn't make sense

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/sophisticatedstorage/recipes/basic_to_netherite_tier_upgrade.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/sophisticatedstorage/recipes/basic_to_netherite_tier_upgrade.json
@@ -8,7 +8,7 @@
   ],
   "ingredients": [
     {
-      "item": "sophisticatedstorage:basic_to_diamond_tier_upgrade"
+      "item": "minecraft:redstone_torch"
     },
     {
       "tag": "forge:ingots/netherite"

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/sophisticatedstorage/recipes/diamond_to_netherite_tier_upgrade.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/sophisticatedstorage/recipes/diamond_to_netherite_tier_upgrade.json
@@ -8,7 +8,7 @@
   ],
   "ingredients": [
     {
-      "item": "minecraft:redstone_torch"
+      "item": "sophisticatedstorage:basic_to_diamond_tier_upgrade"
     },
     {
       "tag": "forge:ingots/netherite"


### PR DESCRIPTION
For the `Netherite` tier upgrade recipes in `Sophisticated Storage`, the following 2 recipes don't seem correct:

- `Diamond to Netherite` requires a `Redstone Torch`
- `Basic to Netherite` requires a `Basic to Diamond Tier Upgrade`

I think these recipes should have been the other way around, as it makes more sense to have the following since it aligns better with the other recipes:

- `Diamond to Netherite` requires a `Basic to Diamond Tier Upgrade`
- `Basic to Netherite` requires a `Redstone Torch`

This PR swaps the ingredients required for these 2 recipes.