### PR TITLE
Disable Growth enchant

### DIFF
--- a/src/minecraft/config/cyclic.toml
+++ b/src/minecraft/config/cyclic.toml
@@ -195,7 +195,7 @@ enabled = true
 # Range: 1 ~ 16
 radius = 2
 # Set false to stop enchantment from working
-enabled = true
+enabled = false
 
 [cyclic.enchantment.step]
 # Set false to stop enchantment from working


### PR DESCRIPTION
This disables the growth enchantment as its way to OP.
To my knowledge there is now option to make it worse, there is only an option to disable it.
Fixes #211