### PR TITLE
Lychee lapis to prismarine

### DIFF
--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/haunting/lapis_to_prismarine_block.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/create_recipes/haunting/lapis_to_prismarine_block.json
@@ -1,0 +1,20 @@
+{
+  "type": "create:haunting",
+  "ingredients": [
+    {
+      "item": "minecraft:lapis_block"
+    }
+  ],
+  "results": [
+    {
+      "chance": 0.75,
+      "item": "minecraft:prismarine_shard",
+      "count": 9
+    },
+    {
+      "chance": 0.125,
+      "item": "minecraft:prismarine_crystals",
+      "count": 9
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_below_soul_fire.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_below_soul_fire.json
@@ -1,0 +1,53 @@
+{
+  "type": "lychee:item_inside",
+  "hide_in_viewer": true,
+  "contextual": [
+    {
+      "type": "location",
+      "offsetY": 1,
+      "predicate": {
+        "block": {
+          "blocks": ["minecraft:soul_fire"]
+        }
+      }
+    }
+  ],
+  "item_in": {
+    "item": "minecraft:lapis_lazuli"
+  },
+  "block_in": {
+    "blocks": ["minecraft:soul_sand"]
+  },
+  "post": [
+    {
+      "type": "random",
+      "empty_weight": 25,
+      "rolls": {
+        "min": 1,
+        "max": 1
+      },
+      "entries": [
+        {
+          "weight": 75,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_shard"
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "empty_weight": 82,
+      "rolls": {
+        "min": 1,
+        "max": 1
+      },
+      "entries": [
+        {
+          "weight": 12,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_crystals"
+        }
+      ]
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_blocks_below_soul_fire.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_blocks_below_soul_fire.json
@@ -1,0 +1,53 @@
+{
+  "type": "lychee:item_inside",
+  "hide_in_viewer": true,
+  "contextual": [
+    {
+      "type": "location",
+      "offsetY": 1,
+      "predicate": {
+        "block": {
+          "blocks": ["minecraft:soul_fire"]
+        }
+      }
+    }
+  ],
+  "item_in": {
+    "item": "minecraft:lapis_block"
+  },
+  "block_in": {
+    "blocks": ["minecraft:soul_sand"]
+  },
+  "post": [
+    {
+      "type": "random",
+      "empty_weight": 25,
+      "rolls": {
+        "min": 9,
+        "max": 9
+      },
+      "entries": [
+        {
+          "weight": 75,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_shard"
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "empty_weight": 82,
+      "rolls": {
+        "min": 9,
+        "max": 9
+      },
+      "entries": [
+        {
+          "weight": 12,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_crystals"
+        }
+      ]
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_blocks_in_soul_fire.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_blocks_in_soul_fire.json
@@ -1,0 +1,41 @@
+{
+  "type": "lychee:item_inside",
+  "item_in": {
+    "item": "minecraft:lapis_block"
+  },
+  "block_in": {
+    "blocks": ["minecraft:soul_fire"]
+  },
+  "post": [
+    {
+      "type": "random",
+      "empty_weight": 25,
+      "rolls": {
+        "min": 9,
+        "max": 9
+      },
+      "entries": [
+        {
+          "weight": 75,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_shard"
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "empty_weight": 82,
+      "rolls": {
+        "min": 9,
+        "max": 9
+      },
+      "entries": [
+        {
+          "weight": 12,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_crystals"
+        }
+      ]
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_in_soul_fire.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/skyfactory_5/recipes/lychee_recipes/in_fire_recipes/prismarine_in_soul_fire.json
@@ -1,0 +1,41 @@
+{
+  "type": "lychee:item_inside",
+  "item_in": {
+    "item": "minecraft:lapis_lazuli"
+  },
+  "block_in": {
+    "blocks": ["minecraft:soul_fire"]
+  },
+  "post": [
+    {
+      "type": "random",
+      "empty_weight": 25,
+      "rolls": {
+        "min": 1,
+        "max": 1
+      },
+      "entries": [
+        {
+          "weight": 75,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_shard"
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "empty_weight": 82,
+      "rolls": {
+        "min": 1,
+        "max": 1
+      },
+      "entries": [
+        {
+          "weight": 12,
+          "type": "drop_item",
+          "item": "minecraft:prismarine_crystals"
+        }
+      ]
+    }
+  ]
+}

--- a/src/minecraft/global_packs/required_data/tag_unification/data/lychee/tags/items/fire_immune.json
+++ b/src/minecraft/global_packs/required_data/tag_unification/data/lychee/tags/items/fire_immune.json
@@ -8,6 +8,10 @@
     "mysticalagriculture:prosperity_shard",
     "minecraft:light_blue_dye",
     "sf5_things:block_of_light_blue_dye",
-    "mysticalagriculture:prosperity_block"
+    "mysticalagriculture:prosperity_block",
+    "minecraft:lapis_lazuli",
+    "minecraft:lapis_block",
+    "minecraft:prismarine_crystals",
+    "minecraft:prismarine_shard"
   ]
 }


### PR DESCRIPTION
Adds Lychee recipes for Lapis to Prismarine, Fixes #342 
Math stays the same from bulk haunting, giving 75% chance for shards, 12% for crystals on average.
Also adds a bulk haunting recipe for the lapis block