### PR TITLE
Disable Conduit Probe

### DIFF
--- a/src/minecraft/config/jei/blacklist.cfg
+++ b/src/minecraft/config/jei/blacklist.cfg
@@ -2057,3 +2057,4 @@ immersiveengineering:nugget_steel
 biggerreactors:wrench
 cyclic:item_infinite
 rftoolsbase:crafting_card
+enderio:conduit_probe

--- a/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/conduit_probe.json
+++ b/src/minecraft/global_packs/required_data/skyfactory_5/data/enderio/recipes/conduit_probe.json
@@ -1,0 +1,7 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ]
+}


### PR DESCRIPTION
The Conduit Probe from EnderIO is currently not functional.
This PR disables it so people dont craft it thinking it works.