### PR TITLE
Block Trophies from CarryOn

### DIFF
--- a/src/minecraft/config/carryon-common.toml
+++ b/src/minecraft/config/carryon-common.toml
@@ -369,7 +369,8 @@ forbiddenTiles = [
   "refurbished_furniture:*",
   "draconicevolution:*",
   "vinery:apple_press",
-  "sushigocrafting:*"
+  "sushigocrafting:*",
+  "obtrophies:*"
 ]
 # Entities that cannot be picked up
 forbiddenEntities = [


### PR DESCRIPTION
The ability to pick them up inteferes with hiding their pedestal with shift+rightclick