### PR TITLE
Disables the Blank issue to force the use of the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This will disable the use of the "Blank Issue" and force issues to use one of the issue templates

<img width="600" alt="image" src="https://github.com/user-attachments/assets/cede25b9-cc3f-4a04-bab0-a3760ca15140" />
