### PR TITLE
Fixes issue with Mystical Crops (Crop Marker and Magenta Seeds)

### DIFF
--- a/src/minecraft/config/crop_marker.json
+++ b/src/minecraft/config/crop_marker.json
@@ -54,18 +54,6 @@
       "hasMarker": true,
       "color": "green"
     },
-    "mysticalagriculture:block/none_crop_crop7": {
-      "offset": 15,
-      "animated": false,
-      "hasMarker": true,
-      "color": "blue"
-    },
-    "mysticalagriculture:block/inferium_crop": {
-      "offset": 15,
-      "animated": false,
-      "hasMarker": true,
-      "color": "blue"
-    },
     "mysticalagriculture:block/flower_dust_resource": {
       "offset": 15,
       "animated": true,

--- a/src/minecraft/config/crop_marker.json
+++ b/src/minecraft/config/crop_marker.json
@@ -59,6 +59,120 @@
       "animated": true,
       "hasMarker": true,
       "color": "red"
+    },
+    "mysticalagriculture:block/inferium_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/coal_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/cobalt_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/dirt_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/prismarine_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/tungsten_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/nature_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/diamond_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/iron_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/experience_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/elementium_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/graphite_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/honey_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/pig_iron_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/draconium_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/redstone_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/dye_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/marble_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
+    },
+    "mysticalagriculture:block/gold_crop": {
+      "offset": 0,
+      "animated": false,
+      "hasMarker": true,
+      "color": "blue"
     }
   }
 }

--- a/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/blockstates/magenta_crop_crop.json
+++ b/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/blockstates/magenta_crop_crop.json
@@ -22,7 +22,7 @@
       "model": "mysticalagriculture:block/mystical_resource_crop_6"
     },
     "age=7": {
-      "model": "mysticalagriculture:block/ghast_crop"
+      "model": "mysticalagriculture:block/elementium_crop"
     }
   }
 }

--- a/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/blockstates/pink_crop_crop.json
+++ b/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/blockstates/pink_crop_crop.json
@@ -22,7 +22,7 @@
       "model": "mysticalagriculture:block/mystical_resource_crop_6"
     },
     "age=7": {
-      "model": "mysticalagriculture:block/elementium_crop"
+      "model": "mysticalagriculture:block/pig_iron_crop"
     }
   }
 }

--- a/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/models/item/magenta_crop_seeds.json
+++ b/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/models/item/magenta_crop_seeds.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "mysticalagriculture:item/none_seeds"
+    "layer0": "mysticalagriculture:item/seeds/elementium_seeds"
   }
 }

--- a/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/models/item/pink_crop_seeds.json
+++ b/src/minecraft/global_packs/required_resources/sf5_resources/assets/mysticalagriculture/models/item/pink_crop_seeds.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "mysticalagriculture:item/seeds/elementium_seeds"
+    "layer0": "mysticalagriculture:item/seeds/pig_iron_seeds"
   }
 }


### PR DESCRIPTION
There is a couple of issues with mystical crops:
![2025-01-30_08 44 51](https://github.com/user-attachments/assets/106359cb-79a4-475a-83b5-80d5f7b31c3c)

Crop Marker offset is incorrect and color is inconsistent.
Also the texture for magenta reuses the ghast flower, which is white.

This PR properly assigns all the crop markers to blue for mystical crops and switches some textures around to fix the colors.
Specifically, Magenta and Pink flowers have had some changes
